### PR TITLE
Use PHP 7.0-friendly var assignment notation

### DIFF
--- a/src/Controller/Rest.php
+++ b/src/Controller/Rest.php
@@ -153,7 +153,8 @@ class Rest extends Base {
 		$args = $request->get_params();
 
 		// destructure entity and action
-		[ 'entity' => $entity, 'action' => $action ] = $args;
+		$entity = $args['entity'];
+		$action = $args['action'];
 
 		// unset unnecessary args
 		unset( $args['entity'], $args['action'], $args['key'], $args['api_key'] );


### PR DESCRIPTION
A fatal error was resulting from the former notation.